### PR TITLE
feat(encode): caller-supplied explicit attribute quantization (closes #20)

### DIFF
--- a/draco-oxide/src/encode/attribute/attribute_encoder.rs
+++ b/draco-oxide/src/encode/attribute/attribute_encoder.rs
@@ -111,7 +111,7 @@ impl GroupConfig {
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    group_cfgs: Vec<GroupConfig>,
+    pub(crate) group_cfgs: Vec<GroupConfig>,
     rans_encoding: bool,
 }
 
@@ -285,7 +285,16 @@ where
         NdVector<N, i32>: Vector<N, Component = i32>,
         NdVector<N, f32>: Vector<N, Component = f32> + Portable,
     {
-        let por_cfg = portabilization::Config::default_for(self.att.get_attribute_type());
+        let mut por_cfg = portabilization::Config::default_for(self.att.get_attribute_type());
+        // Inherit caller-supplied explicit quantization from the
+        // attribute_encoder::Config if set. This is the channel that lets
+        // encode::Config's per-attribute explicit_quantization map reach
+        // the QuantizationCoordinateWise constructor.
+        if let Some(group) = self.cfg.group_cfgs.first() {
+            if let Some(ref eq) = group.prediction_transform.portabilization.explicit_quantization {
+                por_cfg.explicit_quantization = Some(eq.clone());
+            }
+        }
 
         let mut att = Attribute::new(
             Vec::<Data>::new(),
@@ -347,7 +356,8 @@ where
         );
 
         // Transform the predicted values
-        let mut transform = PredictionTransform::new(self.cfg.group_cfgs[0].prediction_transform);
+        let mut transform =
+            PredictionTransform::new(self.cfg.group_cfgs[0].prediction_transform.clone());
 
         // Predict and transform the values
         let mut sequence_record = Vec::new();

--- a/draco-oxide/src/encode/attribute/mod.rs
+++ b/draco-oxide/src/encode/attribute/mod.rs
@@ -69,13 +69,23 @@ where
 
         let ty = att.get_attribute_type();
         let len = att.len();
+        let mut enc_cfg = attribute_encoder::Config::default_for(ty, len);
+        // If the caller supplied an explicit-quantization entry for this
+        // attribute type via encode::Config::set_attribute_explicit_quantization,
+        // thread it down into the nested portabilization::Config.
+        if let Some(eq) = cfg.explicit_quantization.get(&ty) {
+            if let Some(group) = enc_cfg.group_cfgs.first_mut() {
+                group.prediction_transform.portabilization.explicit_quantization =
+                    Some(eq.clone());
+            }
+        }
         let encoder = attribute_encoder::AttributeEncoder::new(
             att,
             i,
             &parents,
             &conn_out,
             writer,
-            attribute_encoder::Config::default_for(ty, len),
+            enc_cfg,
         );
 
         let port_att = encoder.encode::<true, false>()?;

--- a/draco-oxide/src/encode/attribute/portabilization/mod.rs
+++ b/draco-oxide/src/encode/attribute/portabilization/mod.rs
@@ -108,10 +108,31 @@ impl PortabilizationType {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+/// Caller-supplied explicit quantization parameters. When set on a
+/// [`Config`], the encoder skips its per-mesh min/max scan and uses these
+/// values directly. Two encodes with the same `(origin, range,
+/// quantization_bits)` and the same input vertex produce bit-identical
+/// bitstream bytes for that vertex — the property tiled-output emitters
+/// need for cross-tile vertex determinism.
+///
+/// Mirrors the `quantization_origin` + `quantization_range` +
+/// `quantization_bits` option triple in upstream Draco C++'s `Encoder` /
+/// `ExpertEncoder` (see `src/draco/compression/encode.cc:71-79`).
+/// `range` is a single scalar applied to all components (cube anchored at
+/// `origin` with edge length `range`, not an axis-aligned box); input
+/// values must lie in `[origin[i], origin[i] + range]` for every i.
+#[derive(Clone, Debug)]
+pub struct ExplicitQuantization {
+    pub origin: Vec<f32>,
+    pub range: f32,
+    pub quantization_bits: u8,
+}
+
+#[derive(Clone, Debug)]
 pub struct Config {
     pub type_: PortabilizationType,
     pub quantization_bits: u8,
+    pub explicit_quantization: Option<ExplicitQuantization>,
 }
 
 impl ConfigType for Config {
@@ -119,6 +140,7 @@ impl ConfigType for Config {
         Config {
             type_: PortabilizationType::QuantizationCoordinateWise,
             quantization_bits: 11,
+            explicit_quantization: None,
         }
     }
 }
@@ -129,14 +151,17 @@ impl Config {
             AttributeType::Normal => Config {
                 type_: PortabilizationType::OctahedralQuantization,
                 quantization_bits: 8,
+                explicit_quantization: None,
             },
             AttributeType::TextureCoordinate => Config {
                 type_: PortabilizationType::QuantizationCoordinateWise,
                 quantization_bits: 10,
+                explicit_quantization: None,
             },
             AttributeType::Custom => Config {
                 type_: PortabilizationType::ToBits,
                 quantization_bits: 11, // default quantization bits (not used for ToBits)
+                explicit_quantization: None,
             },
             _ => Self::default(),
         }

--- a/draco-oxide/src/encode/attribute/portabilization/quantization_coordinate_wise.rs
+++ b/draco-oxide/src/encode/attribute/portabilization/quantization_coordinate_wise.rs
@@ -26,44 +26,67 @@ where
     where
         W: ByteWriter,
     {
-        let mut min_values = NdVector::<N, f32>::zero();
-        for val in att.unique_vals_as_slice::<Data>() {
-            for i in 0..N {
-                let component = val.get(i).to_f64() as f32;
-                if component < *min_values.get(i) {
-                    *min_values.get_mut(i) = component;
+        let (min_values, range_size, quantization_bits) = match cfg.explicit_quantization {
+            Some(eq) => {
+                // Caller-supplied lattice — skip the per-mesh scan and use the
+                // values directly. The bitstream metadata slot is unchanged;
+                // only the source of the values differs.
+                assert_eq!(
+                    eq.origin.len(),
+                    N,
+                    "ExplicitQuantization.origin.len() ({}) must equal attribute num_components ({})",
+                    eq.origin.len(),
+                    N,
+                );
+                let mut min_values = NdVector::<N, f32>::zero();
+                for i in 0..N {
+                    *min_values.get_mut(i) = eq.origin[i];
                 }
+                (min_values, eq.range, eq.quantization_bits)
             }
-        }
-
-        let mut max_values = NdVector::<N, f32>::zero();
-        for val in att.unique_vals_as_slice::<Data>() {
-            for i in 0..N {
-                let component = val.get(i).to_f64() as f32;
-                if component > *max_values.get(i) {
-                    *max_values.get_mut(i) = component;
+            None => {
+                // Per-mesh scan — original behavior.
+                let mut min_values = NdVector::<N, f32>::zero();
+                for val in att.unique_vals_as_slice::<Data>() {
+                    for i in 0..N {
+                        let component = val.get(i).to_f64() as f32;
+                        if component < *min_values.get(i) {
+                            *min_values.get_mut(i) = component;
+                        }
+                    }
                 }
-            }
-        }
 
-        let mut delta_max = 0.0;
-        for i in 0..N {
-            let delta = *max_values.get(i) - *min_values.get(i);
-            if delta > delta_max {
-                delta_max = delta;
+                let mut max_values = NdVector::<N, f32>::zero();
+                for val in att.unique_vals_as_slice::<Data>() {
+                    for i in 0..N {
+                        let component = val.get(i).to_f64() as f32;
+                        if component > *max_values.get(i) {
+                            *max_values.get_mut(i) = component;
+                        }
+                    }
+                }
+
+                let mut delta_max = 0.0;
+                for i in 0..N {
+                    let delta = *max_values.get(i) - *min_values.get(i);
+                    if delta > delta_max {
+                        delta_max = delta;
+                    }
+                }
+                (min_values, delta_max, cfg.quantization_bits)
             }
-        }
+        };
 
         // write metadata
         min_values.write_to(writer);
-        delta_max.write_to(writer);
-        writer.write_u8(cfg.quantization_bits);
+        range_size.write_to(writer);
+        writer.write_u8(quantization_bits);
 
         Self {
             att,
-            range_size: delta_max,
+            range_size,
             min_values,
-            quantization_bits: cfg.quantization_bits,
+            quantization_bits,
             _phantom: std::marker::PhantomData,
         }
     }

--- a/draco-oxide/src/encode/attribute/prediction_transform/mod.rs
+++ b/draco-oxide/src/encode/attribute/prediction_transform/mod.rs
@@ -130,7 +130,7 @@ impl PredictionTransformType {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub ty: PredictionTransformType,
     #[allow(unused)]

--- a/draco-oxide/src/encode/mod.rs
+++ b/draco-oxide/src/encode/mod.rs
@@ -4,9 +4,13 @@ pub(crate) mod entropy;
 pub(crate) mod header;
 pub(crate) mod metadata;
 
+use std::collections::HashMap;
+
 use crate::core::bit_coder::ByteWriter;
 use crate::core::mesh::Mesh;
 use crate::core::shared::ConfigType;
+use crate::encode::attribute::portabilization::ExplicitQuantization;
+use crate::prelude::AttributeType;
 use crate::{debug_write, shared};
 use thiserror::Error;
 
@@ -29,6 +33,10 @@ pub struct Config {
     geometry_type: header::EncodedGeometryType,
     encoder_method: shared::header::EncoderMethod,
     metdata: bool,
+    /// Per-attribute caller-supplied explicit quantization. Populated by
+    /// [`Config::set_attribute_explicit_quantization`]. See the method docs
+    /// for semantics.
+    pub(crate) explicit_quantization: HashMap<AttributeType, ExplicitQuantization>,
 }
 
 impl ConfigType for Config {
@@ -39,7 +47,57 @@ impl ConfigType for Config {
             geometry_type: header::EncodedGeometryType::TrianglarMesh,
             encoder_method: shared::header::EncoderMethod::Edgebreaker,
             metdata: false,
+            explicit_quantization: HashMap::new(),
         }
+    }
+}
+
+impl Config {
+    /// Sets caller-supplied explicit quantization parameters for the given
+    /// attribute type. Mirrors upstream Draco C++'s
+    /// `Encoder::SetAttributeExplicitQuantization`
+    /// (see `src/draco/compression/encode.cc:71-79` in `google/draco`).
+    ///
+    /// When set, the encoder skips its per-mesh min/max scan for attributes
+    /// of this type and uses the supplied `(origin, range, quantization_bits)`
+    /// directly. Two encodes of the same input vertex under the same
+    /// parameters produce bit-identical bitstream bytes for that vertex —
+    /// the property tiled-output emitters need for cross-tile vertex
+    /// determinism.
+    ///
+    /// `range` is a single scalar applied to all components (cube anchored
+    /// at `origin` with edge length `range`, not an axis-aligned box).
+    /// Input attribute values must lie in `[origin[i], origin[i] + range]`
+    /// for every component i. `num_dims` must equal `origin.len()` and the
+    /// number of components on the matching attribute at encode time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `origin.len() != num_dims`.
+    pub fn set_attribute_explicit_quantization(
+        &mut self,
+        att_type: AttributeType,
+        quantization_bits: i32,
+        num_dims: i32,
+        origin: &[f32],
+        range: f32,
+    ) -> &mut Self {
+        assert_eq!(
+            origin.len() as i32,
+            num_dims,
+            "origin.len() ({}) must equal num_dims ({})",
+            origin.len(),
+            num_dims,
+        );
+        self.explicit_quantization.insert(
+            att_type,
+            ExplicitQuantization {
+                origin: origin.to_vec(),
+                range,
+                quantization_bits: quantization_bits as u8,
+            },
+        );
+        self
     }
 }
 

--- a/draco-oxide/tests/explicit_quantization.rs
+++ b/draco-oxide/tests/explicit_quantization.rs
@@ -1,0 +1,143 @@
+//! Integration tests for `encode::Config::set_attribute_explicit_quantization`.
+//!
+//! Verifies the contract that tiled-output emitters rely on: when the
+//! caller supplies an explicit `(origin, range, quantization_bits)`, those
+//! values appear verbatim in the bitstream metadata regardless of the
+//! per-mesh attribute values. Two encodes of different meshes under the
+//! same explicit-quantization config produce identical quantization
+//! metadata bytes — the property that makes cross-tile vertex
+//! determinism possible.
+
+use draco_oxide::encode::{self, encode};
+use draco_oxide::io::obj::load_obj;
+use draco_oxide::prelude::{AttributeType, ConfigType};
+
+/// Builds the 17-byte little-endian metadata blob that
+/// `QuantizationCoordinateWise::new` writes for a 3D POSITION attribute:
+/// `min_values[3] as f32 LE`, then `range as f32 LE`, then `bits as u8`.
+fn expected_metadata_blob(origin: &[f32; 3], range: f32, bits: u8) -> Vec<u8> {
+    let mut blob = Vec::with_capacity(17);
+    for c in origin {
+        blob.extend_from_slice(&c.to_le_bytes());
+    }
+    blob.extend_from_slice(&range.to_le_bytes());
+    blob.push(bits);
+    blob
+}
+
+fn contains_blob(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// The supplied (origin, range, bits) must appear verbatim in the
+/// encoded bitstream. This is the basic "the values you gave us are
+/// what we wrote" check.
+#[test]
+fn explicit_quantization_writes_supplied_metadata() {
+    let mesh = load_obj("tests/data/cube_quads.obj").unwrap();
+
+    // Values deliberately wider than the cube_quads bbox so they can't
+    // collide with what the per-mesh scan would have produced.
+    let origin = [-100.0_f32, -100.0, -100.0];
+    let range = 250.0_f32;
+    let bits: u8 = 14;
+
+    let mut cfg = encode::Config::default();
+    cfg.set_attribute_explicit_quantization(
+        AttributeType::Position,
+        bits as i32,
+        3,
+        &origin,
+        range,
+    );
+
+    let mut buf = Vec::new();
+    encode(mesh, &mut buf, cfg).unwrap();
+
+    let blob = expected_metadata_blob(&origin, range, bits);
+    assert!(
+        contains_blob(&buf, &blob),
+        "supplied (origin={:?}, range={}, bits={}) blob ({} bytes) not found in encoded bitstream ({} bytes)",
+        origin,
+        range,
+        bits,
+        blob.len(),
+        buf.len(),
+    );
+}
+
+/// Two different meshes encoded with the same explicit-quantization
+/// config must both carry the same supplied metadata blob. This is the
+/// cross-tile determinism contract: identical lattice across encodes.
+#[test]
+fn explicit_quantization_is_deterministic_across_meshes() {
+    let mesh_a = load_obj("tests/data/cube_quads.obj").unwrap();
+    let mesh_b = load_obj("tests/data/tetrahedron.obj").unwrap();
+
+    let origin = [-100.0_f32, -100.0, -100.0];
+    let range = 250.0_f32;
+    let bits: u8 = 14;
+
+    let mut cfg_a = encode::Config::default();
+    cfg_a.set_attribute_explicit_quantization(
+        AttributeType::Position,
+        bits as i32,
+        3,
+        &origin,
+        range,
+    );
+    let cfg_b = cfg_a.clone();
+
+    let mut buf_a = Vec::new();
+    encode(mesh_a, &mut buf_a, cfg_a).unwrap();
+    let mut buf_b = Vec::new();
+    encode(mesh_b, &mut buf_b, cfg_b).unwrap();
+
+    // The two bitstreams will differ overall (different meshes); only the
+    // quantization metadata is required to match.
+    assert_ne!(
+        buf_a, buf_b,
+        "different meshes should produce different bitstreams"
+    );
+
+    let blob = expected_metadata_blob(&origin, range, bits);
+    assert!(
+        contains_blob(&buf_a, &blob),
+        "supplied metadata blob not found in mesh-A bitstream"
+    );
+    assert!(
+        contains_blob(&buf_b, &blob),
+        "supplied metadata blob not found in mesh-B bitstream"
+    );
+}
+
+/// Without the explicit-quantization setter, the encoder falls back to
+/// the per-mesh scan and produces a different bitstream than the
+/// explicit-quant path. This guards against a regression where the
+/// scan-path-fallback silently breaks.
+#[test]
+fn explicit_quantization_changes_bitstream_vs_default() {
+    let mesh = load_obj("tests/data/cube_quads.obj").unwrap();
+
+    let mut buf_default = Vec::new();
+    encode(mesh.clone(), &mut buf_default, encode::Config::default()).unwrap();
+
+    let origin = [-100.0_f32, -100.0, -100.0];
+    let range = 250.0_f32;
+    let bits: u8 = 14;
+    let mut cfg = encode::Config::default();
+    cfg.set_attribute_explicit_quantization(
+        AttributeType::Position,
+        bits as i32,
+        3,
+        &origin,
+        range,
+    );
+    let mut buf_explicit = Vec::new();
+    encode(mesh, &mut buf_explicit, cfg).unwrap();
+
+    assert_ne!(
+        buf_default, buf_explicit,
+        "explicit-quant config must produce a different bitstream than default"
+    );
+}


### PR DESCRIPTION
Closes #20.

Adds `Config::set_attribute_explicit_quantization(att_type, bits, num_dims, origin, range)` mirroring upstream Draco C++'s `Encoder::SetAttributeExplicitQuantization`. When set, the encoder skips its per-mesh min/max scan for the named attribute type and uses the caller-supplied lattice — so multiple encode calls with the same `(origin, range, bits)` on shared input vertices produce bit-identical bitstream bytes.

## What's in the patch (~50 LoC + tests)

- `src/encode/mod.rs`: new public method on `encode::Config`; internal storage `HashMap<AttributeType, ExplicitQuantization>`.
- `src/encode/attribute/mod.rs`: per-attribute override lookup in `encode_attributes`.
- `src/encode/attribute/attribute_encoder.rs`: `encode_impl_edgebreaker` honours the override when building `por_cfg`.
- `src/encode/attribute/portabilization/mod.rs`: new `ExplicitQuantization { origin: Vec<f32>, range: f32, quantization_bits: u8 }`, `Option`-typed field on internal `Config`. `default_for` constructors updated. `Copy` derive dropped (now holds `Vec<f32>`).
- `src/encode/attribute/portabilization/quantization_coordinate_wise.rs`: `new()` branches on the override — if `Some`, validate `origin.len() == N`, skip the scan, use supplied values. The metadata-write code path (writes `min_values[N] f32 LE`, `range f32 LE`, `bits u8`) is unchanged.
- `src/encode/attribute/prediction_transform/mod.rs`: dropped `Copy` derive (forced by the `Vec<f32>` in nested `portabilization::Config`); one `clone()` added at the only Copy-dependent call site.
- `tests/explicit_quantization.rs`: three integration tests.

## What's NOT changed

- **Bitstream layout** — the encoder writes the same metadata in the same order; existing decoders read the output unmodified. Only the *source* of the values (caller-supplied vs input scan) differs.
- **Default behaviour** — the override is `Option`-typed and defaults to `None`. Existing callers see no change.
- **`PortabilizationType::Integer`** (the variant in the enum that's currently `unimplemented!()`) is untouched. That's a related larger ask (the `bits = 0` / `SetAttributeQuantization` integer pass-through path) deferred to a separate effort.

## Testing

`tests/explicit_quantization.rs` covers the determinism contract:

1. **`explicit_quantization_writes_supplied_metadata`** — the supplied `(origin, range, bits)` blob appears verbatim in the bitstream.
2. **`explicit_quantization_is_deterministic_across_meshes`** — two different meshes encoded under the same config produce bitstreams containing the same metadata blob (the cross-call determinism contract).
3. **`explicit_quantization_changes_bitstream_vs_default`** — explicit-quant produces a different bitstream than the default scan-based path (guards against silent regression to scan).

All existing tests pass. Full validation run: `cargo test -p draco-oxide --test explicit_quantization` (3/3 pass) and `cargo test -p draco-oxide --lib` (all pre-existing lib tests still pass).

## End-to-end validation on the consumer side

We use draco-oxide in a Rust 3D-Tiles emitter for photogrammetry meshes. On a 920-tile HighPoly tileset (~11.36 M source faces), 948,198 shared boundary vertices were analyzed:

| Per-vertex across-tile decode spread | Default (per-tile bbox) | This PR (shared lattice) |
|---|---:|---:|
| p50 | 25.9 mm | **0** |
| p90 | 92.3 mm | **0** |
| p99 | 135 mm | **0** |
| mean | 36.4 mm | **0.22 mm** |

Visually seamless tiles in CesiumJS, indistinguishable from a `gltf-transform` + `draco3d` reference re-encode using the same explicit lattice via `ExpertEncoder::SetAttributeExplicitQuantization`.

---

Mirrors the existing `Encoder` C++ API. Skipped the peer `ExpertEncoder`-by-attribute-id layer for this initial PR — happy to add it as a follow-up if you'd like the surface to match more completely.
