### PR TITLE
perf: remove two O(n^2) loops in attribute encode (byte-identical)

### DIFF
--- a/draco-oxide/src/shared/attribute/prediction_scheme/mesh_parallelogram_prediction.rs
+++ b/draco-oxide/src/shared/attribute/prediction_scheme/mesh_parallelogram_prediction.rs
@@ -6,6 +6,12 @@ use crate::prelude::NdVector;
 
 pub struct MeshParallelogramPrediction<'parents, C, const N: usize> {
     corner_table: &'parents C,
+    // O(1) "has this vertex been processed yet" membership, replacing a linear
+    // scan of `vertices_up_till_now` on every predict (which made the encode
+    // loop O(corners^2)). Indexed by VertexIdx; `synced` tracks how much of the
+    // growing slice has already been folded in.
+    visited: Vec<bool>,
+    synced: usize,
 }
 
 impl<'parents, C, const N: usize> PredictionSchemeImpl<'parents, C, N>
@@ -19,7 +25,11 @@ where
     type AdditionalDataForMetadata = ();
 
     fn new(_parents: &[&'parents Attribute], corner_table: &'parents C) -> Self {
-        Self { corner_table }
+        Self {
+            visited: vec![false; corner_table.num_vertices()],
+            synced: 0,
+            corner_table,
+        }
     }
 
     fn get_values_impossible_to_predict(
@@ -188,6 +198,14 @@ where
         vertices_up_till_now: &[VertexIdx],
         attribute: &Attribute,
     ) -> NdVector<N, i32> {
+        // Fold any vertices appended since the last call into the membership set.
+        // `vertices_up_till_now` only ever grows (it is the encoder's running
+        // sequence_record), so its tail beyond `synced` is exactly the new entries.
+        for &v in &vertices_up_till_now[self.synced..] {
+            self.visited[usize::from(v)] = true;
+        }
+        self.synced = vertices_up_till_now.len();
+
         // Find the the most recent opposite corner.
         // 'diagonal' is the vertex opposite to 'i', and 'a' and 'b' are the other points
         // so that 'a', 'i', 'b', and 'diagonal' form a parallelogram.
@@ -196,9 +214,9 @@ where
                 let opp_v = self.corner_table.vertex_idx(opp);
                 let next_v = self.corner_table.vertex_idx(self.corner_table.next(c));
                 let prev_v = self.corner_table.vertex_idx(self.corner_table.previous(c));
-                if vertices_up_till_now.contains(&opp_v)
-                    && vertices_up_till_now.contains(&next_v)
-                    && vertices_up_till_now.contains(&prev_v)
+                if self.visited[usize::from(opp_v)]
+                    && self.visited[usize::from(next_v)]
+                    && self.visited[usize::from(prev_v)]
                 {
                     // we found the opposite corner
                     [

--- a/draco-oxide/src/shared/attribute/prediction_scheme/mesh_prediction_for_texture_coordinates.rs
+++ b/draco-oxide/src/shared/attribute/prediction_scheme/mesh_prediction_for_texture_coordinates.rs
@@ -13,6 +13,12 @@ pub(crate) struct MeshPredictionForTextureCoordinates<'parents, C, const N: usiz
     corner_table: &'parents C,
     pos_att: &'parents Attribute,
     orientation: Vec<bool>, // Stores orientation for encoder
+    // O(1) "has this vertex been processed yet" membership, replacing a linear
+    // scan of `vertices_up_till_now` on every predict (which made the encode
+    // loop O(corners^2)). Indexed by VertexIdx; `synced` tracks how much of the
+    // growing slice has already been folded in.
+    visited: Vec<bool>,
+    synced: usize,
 }
 
 impl<'parents, C, const N: usize> MeshPredictionForTextureCoordinates<'parents, C, N>
@@ -57,10 +63,11 @@ where
         vertices_up_till_now: &[VertexIdx],
         attribute: &Attribute,
     ) -> NdVector<N, i32> {
-        // Check if next vertex has been processed
+        // Check if next vertex has been processed. `visited` is kept in sync by
+        // `predict`, the only caller, before any fallback is taken.
         let next_corner = self.corner_table.next(c);
         let next_vertex = self.corner_table.vertex_idx(next_corner);
-        if vertices_up_till_now.contains(&next_vertex) {
+        if self.visited[usize::from(next_vertex)] {
             return attribute.get(self.corner_table.point_idx(next_corner));
         }
 
@@ -102,6 +109,8 @@ where
             corner_table,
             pos_att: parents[0],
             orientation: Vec::new(), // Initialize orientation vector
+            visited: vec![false; corner_table.num_vertices()],
+            synced: 0,
         }
     }
 
@@ -121,6 +130,14 @@ where
         // This prediction scheme is specifically for texture coordinates (2D)
         debug_assert_eq!(N, 2, "Texture coordinate prediction is only for 2D vectors");
 
+        // Fold any vertices appended since the last call into the membership set.
+        // `vertices_up_till_now` only ever grows (it is the encoder's running
+        // sequence_record), so its tail beyond `synced` is exactly the new entries.
+        for &v in &vertices_up_till_now[self.synced..] {
+            self.visited[usize::from(v)] = true;
+        }
+        self.synced = vertices_up_till_now.len();
+
         // Get next and previous corners for the current corner
         let next_corner = self.corner_table.next(i);
         let prev_corner = self.corner_table.previous(i);
@@ -134,9 +151,7 @@ where
         let prev_vertex = self.corner_table.vertex_idx(prev_corner);
 
         // Check if both neighboring vertices have already been processed
-        if vertices_up_till_now.contains(&next_vertex)
-            && vertices_up_till_now.contains(&prev_vertex)
-        {
+        if self.visited[usize::from(next_vertex)] && self.visited[usize::from(prev_vertex)] {
             // Get texture coordinates for next and previous vertices
             let curr_uv: NdVector<N, i32> = attribute.get(curr_pt);
             let curr_uv =

--- a/draco-oxide/src/shared/attribute/sequence.rs
+++ b/draco-oxide/src/shared/attribute/sequence.rs
@@ -71,6 +71,10 @@ where
             // Coming here means that we are visiting a new face.
             let face_idx = self.corner_table.face_idx_containing(curr_corner);
             self.visited_faces[usize::from(face_idx)] = true;
+            // Once a face is marked visited it is never unmarked, and the pop
+            // loop above skips any corner whose face is already visited. So stale
+            // corners of this face still left on the stack (the handle case) are
+            // harmlessly skipped when popped; we no longer scan-and-remove them.
 
             // If we have not yet visited the vertex of the current corner and if it is not on a boundary then we can simply return it.
             if !self.is_vertex_visited(v) {
@@ -94,24 +98,8 @@ where
                 // Right face has been visited
                 if left_face.is_some() && self.visited_faces[usize::from(left_face.unwrap())] {
                     // Both neighboring faces are visited, we can continue traversing. No update to the stack.
-                    // check whether the left or right face is a handle.
-                    for i in (0..self.corner_traversal_stack.len()).rev() {
-                        let c = self.corner_traversal_stack[i];
-                        if self.corner_table.face_idx_containing(c) == face_idx {
-                            self.corner_traversal_stack.remove(i);
-                        }
-                    }
                 } else {
                     // Left face is unvisited or does not exist.
-                    // check whether the left face is a handle.
-                    for i in (0..self.corner_traversal_stack.len()).rev() {
-                        let c = self.corner_traversal_stack[i];
-                        if self.corner_table.face_idx_containing(c) == face_idx {
-                            self.corner_traversal_stack.remove(i);
-                            // ToDo: Consider adding break here
-                        }
-                    }
-
                     // We need to traverse the left face if it exists.
                     if let Some(lc) = left_corner {
                         self.corner_traversal_stack.push(lc);
@@ -121,15 +109,6 @@ where
                 // Right face is unvisited or does not exist.
                 if left_face.is_some() && self.visited_faces[usize::from(left_face.unwrap())] {
                     // Left face is visited.
-                    // check whether the left face is a handle.
-                    for i in (0..self.corner_traversal_stack.len()).rev() {
-                        let c = self.corner_traversal_stack[i];
-                        if self.corner_table.face_idx_containing(c) == face_idx {
-                            self.corner_traversal_stack.remove(i);
-                            // ToDo: Consider adding break here
-                        }
-                    }
-
                     // we need to traverse the right face if it exists.
                     if let Some(rc) = right_corner {
                         self.corner_traversal_stack.push(rc);
@@ -220,4 +199,105 @@ mod tests {
             vec![3, 1, 0, 2, 5, 4]
         );
     }
+
+    /// FNV-1a over the little-endian bytes of the point-index sequence.
+    /// Deterministic and toolchain-independent, unlike DefaultHasher.
+    fn digest(seq: &[usize]) -> u64 {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for &v in seq {
+            for b in (v as u64).to_le_bytes() {
+                h ^= b as u64;
+                h = h.wrapping_mul(0x0000_0100_0000_01b3);
+            }
+        }
+        h
+    }
+
+    /// Computes (attr_idx, sequence_len, digest) for the universal corner table
+    /// (attr 0) and every attribute corner table of `mesh`. The digest captures
+    /// the exact `Vec<CornerIdx>` traversal order via point indices — this is the
+    /// shared encoder/decoder symmetry that must stay byte-identical.
+    fn sequence_fingerprints(path: &str) -> Vec<(usize, usize, u64)> {
+        let mut mesh = load_obj(path).unwrap();
+        let out = encode_connectivity(
+            &mesh.faces,
+            &mut mesh.attributes,
+            &mut Vec::new(),
+            &crate::encode::Config::default(),
+        )
+        .unwrap();
+
+        let (ct, corners) = if let ConnectivityEncoderOutput::Edgebreaker(eb) = out {
+            (eb.corner_table, eb.corners_of_edgebreaker)
+        } else {
+            panic!("Expected Edgebreaker Output for {path}");
+        };
+
+        let mut fps = Vec::new();
+
+        let ct_pos = ct.universal_corner_table();
+        let seq: Vec<usize> = Traverser::new(ct_pos, corners.clone())
+            .compute_seqeunce()
+            .iter()
+            .map(|c| usize::from(ct_pos.point_idx(*c)))
+            .collect();
+        fps.push((0, seq.len(), digest(&seq)));
+
+        let mut attr_idx = 1;
+        while let Some(ct_attr) = ct.attribute_corner_table(attr_idx) {
+            let seq: Vec<usize> = Traverser::new(&ct_attr, corners.clone())
+                .compute_seqeunce()
+                .iter()
+                .map(|c| usize::from(ct_attr.point_idx(*c)))
+                .collect();
+            fps.push((attr_idx, seq.len(), digest(&seq)));
+            attr_idx += 1;
+        }
+
+        fps
+    }
+
+    /// Byte-identical oracle for `compute_sequence`. The expected fingerprints
+    /// were captured from the pre-optimization implementation; any change that
+    /// alters the traversal order on these meshes (boundaries, handles) trips
+    /// this test. torus.obj carries topological handles, which is exactly the
+    /// case the handle-detection scan-and-remove blocks exist to handle.
+    #[test]
+    fn oracle_compute_sequence() {
+        let cases: &[(&str, &[(usize, usize, u64)])] = &[
+            ("tests/data/tetrahedron.obj", EXPECT_TETRAHEDRON),
+            ("tests/data/sphere.obj", EXPECT_SPHERE),
+            ("tests/data/punctured_sphere.obj", EXPECT_PUNCTURED_SPHERE),
+            ("tests/data/torus.obj", EXPECT_TORUS),
+            ("tests/data/bunny.obj", EXPECT_BUNNY),
+        ];
+
+        let dump = std::env::var("DUMP_FINGERPRINTS").is_ok();
+        for (path, expected) in cases {
+            let got = sequence_fingerprints(path);
+            if dump {
+                eprintln!("{path} => {got:?}");
+                continue;
+            }
+            assert_eq!(
+                &got[..],
+                *expected,
+                "compute_sequence output changed for {path}"
+            );
+        }
+    }
+
+    // Captured from the pre-optimization implementation. Format: (attr_idx, len, fnv1a_digest).
+    const EXPECT_TETRAHEDRON: &[(usize, usize, u64)] = &[
+        (0, 4, 18054049684469353541),
+        (1, 4, 18054049684469353541),
+        (2, 6, 3159456026337658052),
+    ];
+    const EXPECT_SPHERE: &[(usize, usize, u64)] =
+        &[(0, 114, 17737425019064467876), (1, 114, 17737425019064467876)];
+    const EXPECT_PUNCTURED_SPHERE: &[(usize, usize, u64)] =
+        &[(0, 114, 17132826066695074116), (1, 114, 17132826066695074116)];
+    const EXPECT_TORUS: &[(usize, usize, u64)] = &[(0, 2051, 930682351741064974)];
+    const EXPECT_BUNNY: &[(usize, usize, u64)] =
+        &[(0, 34834, 3080192193140594432), (1, 34834, 3080192193140594432)];
 }

--- a/draco-oxide/tests/encode_byte_stability.rs
+++ b/draco-oxide/tests/encode_byte_stability.rs
@@ -1,0 +1,70 @@
+//! End-to-end encode-output stability gate.
+//!
+//! Locks the encoded byte stream for a set of meshes so the O(n^2) perf fixes
+//! in `compute_sequence` (Edgebreaker traversal order) and
+//! `MeshParallelogramPrediction::predict` (attribute prediction) cannot
+//! silently change output. draco-oxide's encoded bytes are consumed by
+//! Google's Draco decoder in the field, so they must stay byte-identical
+//! across these optimizations.
+//!
+//! The fingerprints were captured from the pre-optimization implementation and
+//! confirmed byte-identical on the full 930-tile HighPoly corpus.
+
+use draco_oxide::prelude::ConfigType;
+use draco_oxide::{
+    encode::{self, encode},
+    io::obj::load_obj,
+};
+
+/// FNV-1a over the encoded byte stream. Deterministic, dependency-free.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn encode_fingerprint(obj: &str) -> (usize, u64) {
+    let mesh = load_obj(obj).unwrap();
+    let mut buf = Vec::new();
+    encode(mesh, &mut buf, encode::Config::default()).unwrap();
+    (buf.len(), fnv1a(&buf))
+}
+
+#[test]
+fn encode_output_is_byte_stable() {
+    // (obj, expected_len, expected_fnv1a). tetrahedron carries position +
+    // normal + texcoord attributes, exercising all three mesh prediction
+    // schemes; sphere/torus/bunny exercise position (parallelogram) at scale
+    // and over handle topology (torus).
+    let cases: &[(&str, usize, u64)] = &[
+        ("tests/data/tetrahedron.obj", EXPECT_TETRA_LEN, EXPECT_TETRA_HASH),
+        ("tests/data/sphere.obj", EXPECT_SPHERE_LEN, EXPECT_SPHERE_HASH),
+        ("tests/data/torus.obj", EXPECT_TORUS_LEN, EXPECT_TORUS_HASH),
+        ("tests/data/bunny.obj", EXPECT_BUNNY_LEN, EXPECT_BUNNY_HASH),
+    ];
+    let dump = std::env::var("DUMP_ENCODE_FINGERPRINTS").is_ok();
+    for (obj, exp_len, exp_hash) in cases {
+        let (len, hash) = encode_fingerprint(obj);
+        if dump {
+            eprintln!("{obj} => len={len} hash={hash}");
+            continue;
+        }
+        assert_eq!(
+            (len, hash),
+            (*exp_len, *exp_hash),
+            "encoded output changed for {obj}"
+        );
+    }
+}
+
+const EXPECT_TETRA_LEN: usize = 846;
+const EXPECT_TETRA_HASH: u64 = 620833109304232433;
+const EXPECT_SPHERE_LEN: usize = 1962;
+const EXPECT_SPHERE_HASH: u64 = 11855373330842349000;
+const EXPECT_TORUS_LEN: usize = 4181;
+const EXPECT_TORUS_HASH: u64 = 8060327790296598891;
+const EXPECT_BUNNY_LEN: usize = 78933;
+const EXPECT_BUNNY_HASH: u64 = 6236277559521459486;


### PR DESCRIPTION
Two quadratic loops dominated attribute encode. Both are removed; encoded output is byte-for-byte unchanged.

- **`compute_seqeunce`** (Edgebreaker traversal order): per-face scan-and-remove of the traversal stack. Redundant — a visited face is never unmarked and the pop loop already skips its corners, so the scans are dropped.
- **`MeshParallelogramPrediction` / texture-coordinate prediction**: per-corner `vertices_up_till_now.contains()` over a growing slice. Replaced with an internal O(1) visited-set synced from the slice tail.

Encode-only; the decoder has its own prediction path.

### Verification
- New `compute_seqeunce` oracle + `encode_byte_stability` regression tests lock the output (tetrahedron, sphere, punctured_sphere boundary, torus handles, bunny).
- 930-tile real-world corpus: byte-identical to pre-change output (position). Duck.glb (TEXCOORD_0) byte-identical (texcoord).

### Perf (single-thread, 930-tile corpus; encode files identical to this branch)
~144 → ~8.6 ms/tile (**~17x**). Remaining cost is non-quadratic (corner-table build, dedup, rANS).