### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: draco-oxide
+  namespace: reearth
+  description: Rust crate for the Google Draco mesh compression library (WIP)
+  annotations:
+    github.com/project-slug: reearth/draco-oxide
+  links:
+  - url: https://github.com/reearth/draco-oxide
+    title: GitHub
+    icon: github
+  tags:
+  - rust
+  - draco
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/flow


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `draco-oxide` (namespace `reearth`)
- **Owner:** `reearth/flow`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.