### PR TITLE
fix(encode): use WRAP transform for Color attribute so COLOR_0 round-trips

### DIFF
--- a/draco-oxide/src/encode/attribute/attribute_encoder.rs
+++ b/draco-oxide/src/encode/attribute/attribute_encoder.rs
@@ -104,6 +104,29 @@ impl GroupConfig {
                     portabilization: portabilization::Config::default_for(AttributeType::Custom),
                 },
             },
+            // Color (e.g. glTF COLOR_0) — a generic per-vertex attribute with no
+            // mesh-geometry predictor. The reference Draco decoder
+            // (`SequentialIntegerAttributeDecoder::CreateIntPredictionScheme`)
+            // builds a prediction scheme ONLY when the transform type is
+            // `PREDICTION_TRANSFORM_WRAP` (id 1); any other transform — including
+            // the `Difference`/`PREDICTION_TRANSFORM_DELTA` (id 0) default the
+            // `_` catch-all selects — makes the decoder skip the prediction
+            // revert and return the raw quantized residuals (garbage colors,
+            // alpha read as delta-of-constant). Pin Color to the same
+            // reference-compatible delta + wrapped-difference path the Custom arm
+            // uses (PREDICTION_DIFFERENCE + WRAP — also the reference encoder's
+            // generic high-speed path), so draco3d reconstructs absolute colors.
+            AttributeType::Color => Self {
+                range: vec![0..size],
+                prediction_scheme: prediction_scheme::Config {
+                    ty: prediction_scheme::PredictionSchemeType::DeltaPrediction,
+                    ..prediction_scheme::Config::default()
+                },
+                prediction_transform: prediction_transform::Config {
+                    ty: prediction_transform::PredictionTransformType::WrappedDifference,
+                    portabilization: portabilization::Config::default_for(AttributeType::Color),
+                },
+            },
             _ => Self::default_with_size(size),
         }
     }


### PR DESCRIPTION
## Problem

`COLOR_0` vertex attributes encoded by draco-oxide decode to garbage in the reference Draco decoder (the one CesiumJS, `gltf-transform`, and `<model-viewer>` use): out-of-range/negative values, and a constant-`1.0` alpha read out as a delta sequence. A glTF with per-vertex color compressed via `KHR_draco_mesh_compression` therefore renders **black**.

## Root cause

In `GroupConfig::default_for` (`encode/attribute/attribute_encoder.rs`), the `Color` attribute has no explicit arm and falls through `_ => default_with_size`, which selects the `Difference` prediction transform (`PREDICTION_TRANSFORM_DELTA`, id 0).

The reference decoder's `SequentialIntegerAttributeDecoder::CreateIntPredictionScheme` builds a prediction scheme **only** when the transform type is `PREDICTION_TRANSFORM_WRAP` (id 1); for any other transform it returns no scheme, skips the prediction-revert, and returns the raw quantized residuals.
`Position` / `Normal` / `TextureCoordinate` round-trip because their arms already use WRAP/Octahedral transforms — `Color` was the one geometry-agnostic attribute left on the un-invertible default.

## Fix

Add an explicit `AttributeType::Color` arm using `DeltaPrediction` + `WrappedDifference` — the same reference-compatible delta+wrap path the `Custom` arm uses (and the reference encoder's generic high-speed path in
`prediction_scheme_encoder_factory.cc`). One arm, +23 lines; it only affects meshes that carry a `Color` attribute, so all other output is unchanged.

## Verification

Reference-decoded a `COLOR_0` GLB with `gltf-transform` / `draco3d`:

- **before:** garbage (values outside `[0,1]`, broken alpha)
- **after:** exact input colors, alpha `1.0`

Also confirmed visually in a glTF viewer (correct vertex colors; previously black).
