### PR TITLE
gating safety assertions

### DIFF
--- a/draco-oxide/Cargo.toml
+++ b/draco-oxide/Cargo.toml
@@ -32,3 +32,7 @@ evaluation = []
 # Forwards into core so debug output is enabled across every crate, not just here.
 # (Re-add "draco-oxide-decoder?/debug_format" once the decoder dep returns.)
 debug_format = ["draco-oxide-core/debug_format"]
+# Forces the safety-assertion checks on in release builds (default-off; always on
+# in debug via `debug_assertions`). Forwarded into core so the checks in core fire
+# too. (Re-add "draco-oxide-decoder?/safety_assertions" once the decoder dep returns.)
+safety_assertions = ["draco-oxide-core/safety_assertions"]

--- a/draco-oxide/core/Cargo.toml
+++ b/draco-oxide/core/Cargo.toml
@@ -27,3 +27,8 @@ faer = "0.22.6"
 # Resolved at each macro call site, so every crate that invokes them must
 # declare this feature; the `draco-oxide` encoder forwards into it.
 debug_format = []
+# Forces the `safety_assert!` / `safety_assert_eq!` safety checks on even in
+# release builds. Default-off: in debug builds the checks run via
+# `debug_assertions` regardless. Resolved at each macro call site, so every crate
+# that invokes the macros declares it and forwards into core.
+safety_assertions = []

--- a/draco-oxide/core/src/attribute/mod.rs
+++ b/draco-oxide/core/src/attribute/mod.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 use serde::Serialize;
 
 use kiddo::immutable::float::kdtree::ImmutableKdTree;
@@ -335,13 +336,13 @@ impl Attribute {
     /// # Safety:
     /// This function assumes that the indices are valid, i.e. they are within the bounds of the buffer.
     pub fn permute_unchecked(&mut self, indices: &[usize]) {
-        debug_assert!(
+        safety_assert!(
             indices.len() == self.len(),
             "Indices length must match the buffer length: indices.len() = {}, self.len() = {}",
             indices.len(),
             self.len()
         );
-        debug_assert!(
+        safety_assert!(
             indices.iter().all(|&i| i < self.len()),
             "All indices must be within the buffer length: indices = {:?}, self.len() = {}",
             indices,

--- a/draco-oxide/core/src/bit_coder.rs
+++ b/draco-oxide/core/src/bit_coder.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 use std::{iter::Rev, vec};
 
 use super::buffer::{MsbFirst, OrderConfig};
@@ -375,7 +376,7 @@ impl<'buffer, Buffer: ByteReader, Order: OrderConfig> BitReader<'buffer, Buffer,
     /// Reads 'size' bits from the buffer and returns them as a 'u64'.
     /// 'size' must be greater than 0 and less than or equal to 64.
     pub fn read_bits(&mut self, size: u8) -> Result<u64, ReaderErr> {
-        debug_assert!(
+        safety_assert!(
             size > 0 && size <= 64,
             "Size must be between 1 and 64 bits."
         );

--- a/draco-oxide/core/src/buffer/attribute.rs
+++ b/draco-oxide/core/src/buffer/attribute.rs
@@ -1,3 +1,4 @@
+use crate::{safety_assert, safety_assert_eq};
 use serde::ser::SerializeSeq;
 use serde::Serialize;
 use std::{mem, ptr};
@@ -73,12 +74,12 @@ impl AttributeBuffer {
         Data::Component: DataValue,
     {
         let idx = usize::from(idx);
-        debug_assert!(
+        safety_assert!(
             size_of::<Data>() == self.component_type.size() * self.num_components,
             "Cannot read from buffer: Trying to read {}, but the buffer stores the elements of type {} with {} components", 
             size_of::<Data>(), self.component_type.size(), self.num_components
         );
-        debug_assert!(idx < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", idx, self.len);
+        safety_assert!(idx < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", idx, self.len);
         let size = mem::size_of::<Data>();
         let ptr = unsafe { self.as_ptr().add(size * idx) };
         // Safety: upheld
@@ -132,12 +133,12 @@ impl AttributeBuffer {
         Data: Vector<N>,
         Data::Component: DataValue,
     {
-        debug_assert_eq!(
+        safety_assert_eq!(
             Data::Component::get_dyn(), self.component_type,
             "Unsafe Condition Failed: Data type mismatch: Cannot push data of type {:?} into attribute buffer of type {:?}", 
             Data::Component::get_dyn(), self.component_type
         );
-        debug_assert!(
+        safety_assert!(
             N == self.num_components,
             "Unsafe Condition Failed: Number of components mismatch: Cannot push data with {} components into attribute buffer with {} components",
             N, self.num_components
@@ -162,7 +163,7 @@ impl AttributeBuffer {
     /// # Safety
     /// This function assumes that the buffer's data is properly aligned and matches the type `Data`.
     pub unsafe fn as_slice<Data>(&self) -> &[Data] {
-        debug_assert!(
+        safety_assert!(
             mem::size_of::<Data>() == self.component_type.size() * self.num_components,
             "Cannot create slice: Trying to cast to data of size {}, but the buffer stores elements of type {}D vector of {:?}, which has size {}",
             mem::size_of::<Data>(),
@@ -179,7 +180,7 @@ impl AttributeBuffer {
     /// # Safety
     /// This function assumes that the buffer's data is properly aligned and matches the type `Data`.
     pub unsafe fn as_slice_mut<Data>(&mut self) -> &mut [Data] {
-        debug_assert!(
+        safety_assert!(
             mem::size_of::<Data>() == self.component_type.size() * self.num_components,
             "Cannot create slice: Trying to cast to data of size {}, but the buffer stores elements of type {}D vector of {:?}, which has size {}",
             mem::size_of::<Data>(),
@@ -216,14 +217,14 @@ impl AttributeBuffer {
     where
         Data: Vector<N>,
     {
-        debug_assert_eq!(
+        safety_assert_eq!(
             Data::Component::get_dyn(),
             self.component_type,
             "Data type mismatch: Cannot push data of type {:?} into attribute buffer of type {:?}",
             Data::Component::get_dyn(),
             self.component_type
         );
-        debug_assert!(
+        safety_assert!(
             N == self.num_components,
             "Number of components mismatch: Cannot push data with {} components into attribute buffer with {} components",
             N, self.num_components
@@ -251,12 +252,12 @@ impl AttributeBuffer {
     /// (1) it has the same length as the buffer,
     /// (2) its elements are distinct.
     pub unsafe fn permute_unchecked(&mut self, permutation: &[usize]) {
-        debug_assert_eq!(
+        safety_assert_eq!(
             self.len,
             permutation.len(),
             "Permutation length does not match the buffer length"
         );
-        debug_assert!(
+        safety_assert!(
             {
                 let mut p = permutation.to_vec();
                 p.sort();
@@ -284,8 +285,8 @@ impl AttributeBuffer {
     /// # Safety
     /// This function assumes that `i` and `j` are within the bounds of the buffer.
     pub unsafe fn swap_unchecked(&mut self, i: usize, j: usize) {
-        debug_assert!(i < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", i, self.len);
-        debug_assert!(j < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", j, self.len);
+        safety_assert!(i < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", i, self.len);
+        safety_assert!(j < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", j, self.len);
 
         let elem_size = self.num_components * self.component_type.size();
         let ptr_i = unsafe { self.as_ptr().add(i * elem_size) };
@@ -333,7 +334,7 @@ impl AttributeBuffer {
         let elem_size = self.num_components * self.component_type.size();
         let mut write_pos = 0;
         for &idx in keep_indices {
-            debug_assert!(
+            safety_assert!(
                 idx < self.len,
                 "retain_indices: index {} out of bounds (len {})",
                 idx,
@@ -555,7 +556,7 @@ impl MaybeInitAttributeBuffer {
                 .add(len * component_type.size() * num_components)
         };
         let mut initialized_elements = Vec::with_capacity(len);
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "safety_assertions"))]
         {
             initialized_elements.resize(len, false);
         }
@@ -579,7 +580,7 @@ impl MaybeInitAttributeBuffer {
         Data: Vector<N>,
         Data::Component: DataValue,
     {
-        debug_assert_eq!(
+        safety_assert_eq!(
             mem::size_of::<Data>(), self.component_type.size() * self.num_components,
             "Cannot create slice: Trying to cast to {}, but the buffer stores elements of type {}D vector of {:?}, which has size {}",
             mem::size_of::<Data>(), self.num_components, self.component_type, self.component_type.size(),
@@ -620,22 +621,22 @@ impl MaybeInitAttributeBuffer {
         Data: Vector<N>,
         Data::Component: DataValue,
     {
-        debug_assert_eq!(
+        safety_assert_eq!(
             Data::Component::get_dyn(),
             self.component_type,
             "Data type mismatch: Cannot push data of type {:?} into attribute buffer of type {:?}",
             Data::Component::get_dyn(),
             self.component_type
         );
-        debug_assert!(
+        safety_assert!(
             N == self.num_components,
             "Number of components mismatch: Cannot push data with {} components into attribute buffer with {} components",
             N, self.num_components
         );
 
-        debug_assert!(idx < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", idx, self.len);
+        safety_assert!(idx < self.len, "Index out of bounds: The index {} is out of bounds for the attribute buffer with length {}", idx, self.len);
 
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "safety_assertions"))]
         {
             self.initialized_elements[idx] = true;
         }
@@ -669,7 +670,7 @@ impl MaybeInitAttributeBuffer {
 
 impl From<MaybeInitAttributeBuffer> for AttributeBuffer {
     fn from(maybe_init: MaybeInitAttributeBuffer) -> Self {
-        debug_assert!(
+        safety_assert!(
             maybe_init.initialized_elements.iter().all(|&x| x),
             "Not all elements are initialized: Out of {} elements, uninitialized are {:?}",
             maybe_init.len,

--- a/draco-oxide/core/src/buffer/mod.rs
+++ b/draco-oxide/core/src/buffer/mod.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 pub mod attribute;
 // pub mod reader;
 // pub mod writer;
@@ -104,7 +105,7 @@ impl RawBuffer {
     /// expands the buffer to 'new_cap'.
     /// Safety: 'new_cap' must be less than 'usize::Max'.
     unsafe fn expand(&mut self, new_cap: usize) {
-        debug_assert!(new_cap < usize::MAX, "'new_cap' is too large");
+        safety_assert!(new_cap < usize::MAX, "'new_cap' is too large");
         let new_data = alloc::realloc(
             self.data.as_ptr() as *mut u8,
             alloc::Layout::array::<u8>(self.cap).unwrap(),

--- a/draco-oxide/core/src/buffer/reader.rs
+++ b/draco-oxide/core/src/buffer/reader.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 use crate::types::{BitReader, ByteReader};
 
 use super::{OrderConfig, RawBuffer, MsbFirst};
@@ -51,7 +52,7 @@ impl<Order: OrderConfig> ByteReader for Reader<Order, false> {
 	/// the output data is stored in the first 8 bits.
 	fn read_byte(&mut self) -> u8 {
 		assert!(self.num_remaining_bits > 8, "Attempt to read beyond buffer bounds.");
-		debug_assert!(self.pos_in_curr_byte == 0, "Cannot read byte when not at the start of a byte.");
+		safety_assert!(self.pos_in_curr_byte == 0, "Cannot read byte when not at the start of a byte.");
 		let value = unsafe { ptr::read(self.ptr) };
 		self.ptr = unsafe { self.ptr.add(1) };
 		self.num_remaining_bits -= 8;

--- a/draco-oxide/core/src/buffer/writer.rs
+++ b/draco-oxide/core/src/buffer/writer.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 use crate::types::{BitWriter, ByteWriter};
 
 use super::{
@@ -55,7 +56,7 @@ impl<Order: OrderConfig> BitWriter for Writer<Order, true> {
 		}
 
 		// First 'size' bits of 'value' need to contain the data.
-		debug_assert!(
+		safety_assert!(
 			size==64 || value >> size==0,
 			"Invalid Data: 'value' has more than 'size' bits of data: {:?}",
 			(size, value)

--- a/draco-oxide/core/src/codec/attribute/prediction_scheme/derivative_prediction.rs
+++ b/draco-oxide/core/src/codec/attribute/prediction_scheme/derivative_prediction.rs
@@ -81,7 +81,7 @@ where
         // 	let normal = u_pos.cross(v_pos);
         // 	let s = -normal.dot(delta_pos) / normal.dot(normal);
         // 	let out = normal*s + delta_pos;
-        // 	debug_assert!(
+        // 	safety_assert!(
         // 		out.dot(normal).abs() < F::from_f64(1e-6),
         // 		"delta_pos_projected_on_tp must be on the plane defined by u_pos and v_pos, but it is not. \
         // 		delta_pos_projected_on_tp = {:.5?}, normal = {:.5?}, delta_pos = {:.5?}",
@@ -95,7 +95,7 @@ where
         // let s = delta_pos_projected_on_tp.cross(v_pos).dot(u_cross_v) / u_cross_v_norm_squared;
         // let t = u_pos.cross(delta_pos_projected_on_tp).dot(u_cross_v) / u_cross_v_norm_squared;
 
-        // debug_assert!(
+        // safety_assert!(
         // 	(u_pos*s+v_pos*t - delta_pos_projected_on_tp).norm() < F::from_f64(1e-6),
         // 	"u_pos*s+v_pos*t must equal delta_pos_projected_on_tp, but it is not. \
         // 	u_pos*s+v_pos*t = {:?}, delta_pos_projected_on_tp = {:?}",
@@ -149,7 +149,7 @@ where
         // let mut vertices_without_parallelogram: Vec<ops::Range<usize>> = Vec::new();
 
         // for face in self.corner_table {
-        //     debug_assert!(face.is_sorted());
+        //     safety_assert!(face.is_sorted());
         //     let num_unvisited_vertices = face.iter()
         //         .filter(|&&v| v>=is_already_encoded.len() || !is_already_encoded[v])
         //         .count();
@@ -234,15 +234,15 @@ where
 
         //     // [    m    )
         //     //    [    r    )
-        //     debug_assert!(!(r.start > m.start && r.start < m.end && r.end > m.end));
+        //     safety_assert!(!(r.start > m.start && r.start < m.end && r.end > m.end));
 
         //     //     [    m    )
         //     // [    r    )
-        //     debug_assert!(!(r.start > m.start && r.end > m.start && r.end < m.end));
+        //     safety_assert!(!(r.start > m.start && r.end > m.start && r.end < m.end));
 
         //     // [    m    )
         //     //   [  r  )
-        //     debug_assert!(!(r.start < m.start && r.end > m.start && r.end < m.end));
+        //     safety_assert!(!(r.start < m.start && r.end > m.start && r.end < m.end));
 
         //     // The following cases are the only possibilities:
 

--- a/draco-oxide/core/src/codec/attribute/prediction_scheme/mesh_multi_parallelogram_prediction.rs
+++ b/draco-oxide/core/src/codec/attribute/prediction_scheme/mesh_multi_parallelogram_prediction.rs
@@ -118,15 +118,15 @@ where
 
         //     // [    m    )
         //     //    [    r    )
-        //     debug_assert!(!(r.start > m.start && r.start < m.end && r.end > m.end));
+        //     safety_assert!(!(r.start > m.start && r.start < m.end && r.end > m.end));
 
         //     //     [    m    )
         //     // [    r    )
-        //     debug_assert!(!(r.start > m.start && r.end > m.start && r.end < m.end));
+        //     safety_assert!(!(r.start > m.start && r.end > m.start && r.end < m.end));
 
         //     // [    m    )
         //     //   [  r  )
-        //     debug_assert!(!(r.start < m.start && r.end > m.start && r.end < m.end));
+        //     safety_assert!(!(r.start < m.start && r.end > m.start && r.end < m.end));
 
         //     // The following cases are the only possibilities:
 

--- a/draco-oxide/core/src/codec/attribute/prediction_scheme/mesh_parallelogram_prediction.rs
+++ b/draco-oxide/core/src/codec/attribute/prediction_scheme/mesh_parallelogram_prediction.rs
@@ -127,15 +127,15 @@ where
 
         //     // [    m    )
         //     //    [    r    )
-        //     debug_assert!(!(r.start > m.start && r.start < m.end && r.end > m.end));
+        //     safety_assert!(!(r.start > m.start && r.start < m.end && r.end > m.end));
 
         //     //     [    m    )
         //     // [    r    )
-        //     debug_assert!(!(r.start > m.start && r.end > m.start && r.end < m.end));
+        //     safety_assert!(!(r.start > m.start && r.end > m.start && r.end < m.end));
 
         //     // [    m    )
         //     //   [  r  )
-        //     debug_assert!(!(r.start < m.start && r.end > m.start && r.end < m.end));
+        //     safety_assert!(!(r.start < m.start && r.end > m.start && r.end < m.end));
 
         //     // The following cases are the only possibilities:
 

--- a/draco-oxide/core/src/codec/attribute/prediction_scheme/mesh_prediction_for_texture_coordinates.rs
+++ b/draco-oxide/core/src/codec/attribute/prediction_scheme/mesh_prediction_for_texture_coordinates.rs
@@ -3,6 +3,7 @@ use crate::attribute::Attribute;
 use crate::bit_coder::ByteWriter;
 use crate::codec::entropy::rans::RabsCoder;
 use crate::corner_table::GenericCornerTable;
+use crate::safety_assert_eq;
 use crate::types::NdVector;
 use crate::types::{CornerIdx, PointIdx, VertexIdx};
 use crate::types::{Dot, Vector};
@@ -127,7 +128,7 @@ where
         attribute: &Attribute,
     ) -> NdVector<N, i32> {
         // This prediction scheme is specifically for texture coordinates (2D)
-        debug_assert_eq!(N, 2, "Texture coordinate prediction is only for 2D vectors");
+        safety_assert_eq!(N, 2, "Texture coordinate prediction is only for 2D vectors");
 
         // Fold any vertices appended since the last call into the membership set.
         // `vertices_up_till_now` only ever grows (it is the encoder's running

--- a/draco-oxide/core/src/codec/entropy/rans.rs
+++ b/draco-oxide/core/src/codec/entropy/rans.rs
@@ -2,6 +2,7 @@ use crate::bit_coder::ByteWriter;
 use crate::codec::entropy::{
     rans_build_tables, RansSymbol, DEFAULT_RABS_PRECISION, DEFAULT_RANS_PRECISION, L_RANS_BASE,
 };
+use crate::safety_assert;
 use crate::utils::bit_coder::leb128_write;
 
 const SECOND_POW_6: usize = 1 << 6;
@@ -169,7 +170,7 @@ where
             .unwrap()
             .0
             + 1;
-        debug_assert!((num_symbols..freq_counts.len()).all(|i| freq_counts[i] == 0));
+        safety_assert!((num_symbols..freq_counts.len()).all(|i| freq_counts[i] == 0));
 
         let mut distribution = Vec::with_capacity(num_symbols);
         let rans_precision = 1 << RANS_PRECISION;
@@ -213,7 +214,7 @@ where
             }
         }
 
-        debug_assert!(distribution.iter().sum::<usize>() == rans_precision);
+        safety_assert!(distribution.iter().sum::<usize>() == rans_precision);
 
         // encode distribution
         leb128_write(num_symbols as u64, writer);

--- a/draco-oxide/core/src/utils/debug.rs
+++ b/draco-oxide/core/src/utils/debug.rs
@@ -25,3 +25,33 @@ macro_rules! debug_expect {
         }
     };
 }
+
+/// Safety assertion guarding `unsafe` preconditions and internal invariants.
+///
+/// Behaves like `debug_assert!` (active under `cfg(debug_assertions)`) but can
+/// additionally be forced on in release builds by enabling the `safety_assertions`
+/// feature. Default behavior is therefore unchanged: on in debug, off in release.
+///
+/// Like `debug_write!`/`debug_expect!`, the `feature = "safety_assertions"` cfg
+/// resolves at the call site, so every crate invoking this macro must declare the
+/// `safety_assertions` feature (forwarding into core).
+#[macro_export]
+macro_rules! safety_assert {
+    ($($arg:tt)*) => {
+        #[cfg(any(debug_assertions, feature = "safety_assertions"))]
+        {
+            ::core::assert!($($arg)*);
+        }
+    };
+}
+
+/// `assert_eq!` counterpart of [`safety_assert!`]; see that macro for semantics.
+#[macro_export]
+macro_rules! safety_assert_eq {
+    ($($arg:tt)*) => {
+        #[cfg(any(debug_assertions, feature = "safety_assertions"))]
+        {
+            ::core::assert_eq!($($arg)*);
+        }
+    };
+}

--- a/draco-oxide/core/src/utils/geom.rs
+++ b/draco-oxide/core/src/utils/geom.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 use crate::types::{Cross, Dot, Float, NdVector};
 
 /// Calculates the distance from a point to a triangle in 3D space.
@@ -41,6 +42,6 @@ pub fn point_to_line_distance_3d<F: Float>(p: NdVector<3, F>, line: [NdVector<3,
     let dir = (line[1] - line[0]).normalize();
     let p_line0 = p - line[0];
     let n = (p_line0 - dir * p_line0.dot(dir)).normalize();
-    debug_assert!(n.dot(dir).abs() < F::from_f64(1e-6));
+    safety_assert!(n.dot(dir).abs() < F::from_f64(1e-6));
     n.dot(p_line0).abs()
 }

--- a/draco-oxide/core/src/utils/mod.rs
+++ b/draco-oxide/core/src/utils/mod.rs
@@ -1,3 +1,4 @@
+use crate::safety_assert;
 use crate::types::{NdVector, Vector};
 
 pub mod bit_coder;
@@ -71,7 +72,7 @@ pub fn merge_indices(
         }
 
         // Now that 'r.start' is a valid start for the merged range.
-        debug_assert!(
+        safety_assert!(
             iters.iter_mut().all(|(s, _)| s.start <= r.start),
             "r={:?}, current ranges: {:?}",
             r,

--- a/draco-oxide/decoder/Cargo.toml
+++ b/draco-oxide/decoder/Cargo.toml
@@ -20,3 +20,7 @@ enum_dispatch = "0.3.13"
 # core because the `#[cfg(feature = "debug_format")]` in those macros resolves
 # in this crate, not in core.
 debug_format = ["draco-oxide-core/debug_format"]
+# Forces the safety-assertion checks on in release builds (default-off; always on
+# in debug via `debug_assertions`). Forwarded to core for the same call-site
+# resolution reason as `debug_format`.
+safety_assertions = ["draco-oxide-core/safety_assertions"]

--- a/draco-oxide/decoder/src/decode/attribute/inverse_prediction_transform/oct_difference.rs
+++ b/draco-oxide/decoder/src/decode/attribute/inverse_prediction_transform/oct_difference.rs
@@ -1,3 +1,4 @@
+use draco_oxide_core::safety_assert;
 use super::InversePredictionTransformImpl;
 use crate::decode::attribute::portabilization::{Deportabilization, DeportabilizationImpl};
 use draco_oxide_core::codec::attribute::geom::{
@@ -44,7 +45,7 @@ where
         let crr = self.deportabilization.deportabilize_next(reader);
         // Safety:
         // We made sure that the data is three dimensional.
-        debug_assert!(
+        safety_assert!(
             Data::NUM_COMPONENTS == 3,
         );
 

--- a/draco-oxide/decoder/src/decode/attribute/inverse_prediction_transform/oct_orthogonal.rs
+++ b/draco-oxide/decoder/src/decode/attribute/inverse_prediction_transform/oct_orthogonal.rs
@@ -41,7 +41,7 @@ where
 
         // // Safety:
         // // We made sure that the data is three dimensional.
-        // debug_assert!(
+        // safety_assert!(
         //     Data::NUM_COMPONENTS == 3,
         // );
         

--- a/draco-oxide/decoder/src/decode/attribute/inverse_prediction_transform/oct_reflection.rs
+++ b/draco-oxide/decoder/src/decode/attribute/inverse_prediction_transform/oct_reflection.rs
@@ -1,3 +1,4 @@
+use draco_oxide_core::safety_assert;
 use std::result::Result;
 
 use super::InversePredictionTransformImpl;
@@ -44,7 +45,7 @@ impl<Data> InversePredictionTransformImpl for OctahedronReflectionInverseTransfo
         let crr = self.deportabilization.deportabilize_next(reader);
         // Safety:
         // We made sure that the data is three dimensional.
-        debug_assert!(
+        safety_assert!(
             Data::NUM_COMPONENTS == 3,
         );
 

--- a/draco-oxide/decoder/src/decode/connectivity/spirale_reversi.rs
+++ b/draco-oxide/decoder/src/decode/connectivity/spirale_reversi.rs
@@ -1,3 +1,4 @@
+use draco_oxide_core::safety_assert;
 use std::collections::HashMap;
 use std::{cmp, vec, mem};
 use std::io::Read;
@@ -766,7 +767,7 @@ impl SpiraleReversi {
                 if let Some(idx) = self.boundary_edges.binary_search(&new_edge).err() {
                     self.boundary_edges.insert(idx, new_edge);
                 };
-                debug_assert!(self.boundary_edges.is_sorted());
+                safety_assert!(self.boundary_edges.is_sorted());
 
                 // update the right vertex.
                 self.active_edge[0] = next_vertex;
@@ -803,7 +804,7 @@ impl SpiraleReversi {
                 ];
                 let idx = self.boundary_edges.binary_search(&new_edge).unwrap_err();
                 self.boundary_edges.insert(idx, new_edge);
-                debug_assert!(self.boundary_edges.is_sorted());
+                safety_assert!(self.boundary_edges.is_sorted());
 
                 self.active_edge[1] = self.num_decoded_vertices;
                 self.num_decoded_vertices += 1;
@@ -838,7 +839,7 @@ impl SpiraleReversi {
                 ];
                 let idx = self.boundary_edges.binary_search(&new_edge).unwrap_err();
                 self.boundary_edges.insert(idx, new_edge);
-                debug_assert!(self.boundary_edges.is_sorted());
+                safety_assert!(self.boundary_edges.is_sorted());
 
                 self.active_edge[0] = self.num_decoded_vertices;
                 self.num_decoded_vertices += 1;
@@ -855,7 +856,7 @@ impl SpiraleReversi {
                     self.faces.push(new_face);
 
                     // modify the boundary edges
-                    debug_assert!(self.boundary_edges.is_empty());
+                    safety_assert!(self.boundary_edges.is_empty());
                     self.boundary_edges.push([new_face[0], new_face[1]]);
                     self.boundary_edges.push([new_face[0], new_face[2]]);
                     self.boundary_edges.push([new_face[1], new_face[2]]);
@@ -879,7 +880,7 @@ impl SpiraleReversi {
                     self.boundary_edges.push([new_face[0], new_face[1]]);
                     self.boundary_edges.push([new_face[0], new_face[2]]);
                     self.boundary_edges.push([new_face[1], new_face[2]]);
-                    debug_assert!(self.boundary_edges.is_sorted());
+                    safety_assert!(self.boundary_edges.is_sorted());
 
                     self.active_edge_stack.push(self.active_edge);
                     // choose any edge of the triangle
@@ -923,7 +924,7 @@ impl SpiraleReversi {
                 ];
                 let idx = self.boundary_edges.binary_search(&new_edge).unwrap_err();
                 self.boundary_edges.insert(idx, new_edge);
-                debug_assert!(self.boundary_edges.is_sorted());
+                safety_assert!(self.boundary_edges.is_sorted());
 
                 // now that the right vertex of the active edge is removed, we need to renumber
                 // the vertices numbered after the vertex.

--- a/draco-oxide/src/encode/attribute/portabilization/octahedral_quantization.rs
+++ b/draco-oxide/src/encode/attribute/portabilization/octahedral_quantization.rs
@@ -4,6 +4,7 @@ use draco_oxide_core::bit_coder::ByteWriter;
 use draco_oxide_core::codec::attribute::geom::into_faithful_oct_quantization;
 use draco_oxide_core::codec::attribute::geom::octahedral_transform;
 use draco_oxide_core::codec::attribute::Portable;
+use draco_oxide_core::safety_assert;
 use draco_oxide_core::types::AttributeValueIdx;
 use draco_oxide_core::types::NdVector;
 use draco_oxide_core::types::Vector;
@@ -48,7 +49,7 @@ where
 
     fn portabilize_value(&mut self, val: Data) -> NdVector<2, i32> {
         let val_oct = octahedral_transform(val) + NdVector::<2, f32>::from([1.0, 1.0]);
-        debug_assert!(
+        safety_assert!(
             *val_oct.get(0) >= 0.0
                 && *val_oct.get(0) <= 2.0
                 && *val_oct.get(1) >= 0.0

--- a/draco-oxide/src/encode/attribute/prediction_transform/oct_reflection.rs
+++ b/draco-oxide/src/encode/attribute/prediction_transform/oct_reflection.rs
@@ -1,4 +1,5 @@
 use draco_oxide_core::bit_coder::ByteWriter;
+use draco_oxide_core::safety_assert;
 use draco_oxide_core::types::{NdVector, Vector};
 
 use super::PredictionTransformImpl;
@@ -23,7 +24,7 @@ impl<const N: usize> PredictionTransformImpl<N> for OctahedronReflectionTransfor
     {
         // Safety:
         // We made sure that the data is three dimensional.
-        debug_assert!(N == 2,);
+        safety_assert!(N == 2,);
 
         unsafe {
             if *pred.get_unchecked(2) < 0 {

--- a/draco-oxide/src/encode/attribute/prediction_transform/orthogonal.rs
+++ b/draco-oxide/src/encode/attribute/prediction_transform/orthogonal.rs
@@ -59,8 +59,8 @@ impl<const N: usize> PredictionTransformImpl<N> for OrthogonalTransform<N> {
 
         // let pred_cross_orig = pred.cross(orig);
         // // 'ref_on_pred_perp' and pred_'cross_orig' are on the same plane defined by 'pred'
-        // debug_assert!(pred_cross_orig.dot(pred).abs() < one/Data::Component::from_u64(1_000_000));
-        // debug_assert!(ref_on_pred_perp.dot(pred).abs() < one/Data::Component::from_u64(1_000_000));
+        // safety_assert!(pred_cross_orig.dot(pred).abs() < one/Data::Component::from_u64(1_000_000));
+        // safety_assert!(ref_on_pred_perp.dot(pred).abs() < one/Data::Component::from_u64(1_000_000));
 
         // // get the angle between 'ref_on_pred_perp' and 'pred_cross_orig'
         // let ref_on_pred_perp_norm_squared = ref_on_pred_perp.dot(ref_on_pred_perp).to_f64();


### PR DESCRIPTION
There are safety assertions everywhere in order to empirically double-check the safety conditions of unsafe code, that only run in debug build. This feature is now gated through the new `safety_assertions` feature.
This PR doesn't change the default behavior.