### PR TITLE
fix: decoder rans_refill never refills on 32-bit targets

### DIFF
--- a/draco-oxide/decoder/src/reader.rs
+++ b/draco-oxide/decoder/src/reader.rs
@@ -61,8 +61,10 @@ impl<'a> RevReader<'a> {
             let l_bits = l_base.trailing_zeros() as usize;
             // `state | 1` guards the (malformed-stream-only) state == 0 case;
             // it never changes the bit length of a live state, which is >= 4
-            // whenever bytes remain.
-            let msb = 63 - (state | 1).leading_zeros() as usize;
+            // whenever bytes remain. usize::BITS, not 63: on wasm32 usize is
+            // 32 bits, and a 64-based msb overshoots by 32 so k saturates to 0
+            // and the state is never refilled.
+            let msb = (usize::BITS - 1 - (state | 1).leading_zeros()) as usize;
             // Smallest k with the refilled bit length reaching l_bits; k <= 3
             // because states stay below l_base << 8 = 2^(l_bits + 8).
             let k = (l_bits.saturating_sub(msb) + 7) >> 3;
@@ -117,6 +119,29 @@ mod tests {
         assert_eq!(reader.read_u8().unwrap(), 4);
         assert_eq!(reader.read_u8().unwrap(), 5);
         assert!(reader.is_empty());
+    }
+
+    /// The branchless refill must match the byte-loop it replaces for every
+    /// state below l_base, at every draco precision. Runs the widths that
+    /// need 1, 2 and 3 refill bytes; on a 32-bit usize the fast path is the
+    /// same arithmetic, so this pins the width-portable msb computation.
+    #[test]
+    fn rans_refill_fast_path_matches_byte_loop() {
+        let buffer = vec![0x11_u8, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        for precision in [12_usize, 16, 20] {
+            let l_base = 4_usize << precision;
+            for state in [1_usize, 0x3F, 0x1FFF, l_base >> 9, l_base - 1] {
+                let mut fast = RevReader::new(&buffer);
+                let refilled = fast.rans_refill(state, l_base);
+                let mut slow = RevReader::new(&buffer);
+                let mut expected = state;
+                while expected < l_base {
+                    expected = (expected << 8) | slow.read_u8_back().unwrap() as usize;
+                }
+                assert_eq!(refilled, expected, "state {state:#x} precision {precision}");
+                assert_eq!(fast.read_u8_back(), slow.read_u8_back());
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
On wasm32 (or any 32-bit target), `RevReader::rans_refill`'s branchless fast path computes the state's msb index as `63 - state.leading_zeros()` with `state: usize`. With a 32-bit `usize`, `leading_zeros()` is relative to 32 bits, so the index comes out 32 too high, `k` saturates to 0, and the fast path never refills the state. Every stream whose encoder selected the branchless refill strategy decodes to garbage symbols on wasm32 — quantized attributes come out corrupted, or the reader desyncs into framing errors like `malformed attribute section: unknown prediction scheme id` — while the same streams decode correctly on 64-bit.

We hit this in production in [decentraland/bevy-explorer](https://github.com/decentraland/bevy-explorer) (native client fine, wasm client corrupted/failing): 12 gltf-pipeline-encoded draco streams from real content reproduced it, with the failures data-dependent (only streams on the branchless path break, which made it look nondeterministic at first).

The fix is one line: width the msb computation with `usize::BITS`. A 32-bit state is sufficient throughout — precision never exceeds 20, so states stay below `l_base << 8` = 2^30 — the only width assumption was this constant.

Also adds a unit test pinning the fast path to the byte-loop it replaces across the 1/2/3-refill-byte widths. On 64-bit it pins the arithmetic; on a 32-bit target it catches this bug (verified: it fails without the fix and passes with it via `cargo test -p draco-oxide-decoder --target wasm32-wasip1` with a wasmtime runner). With the fix, the decoder and core suites pass on wasm32-wasip1, the full workspace suite passes natively, and our 12 previously-failing streams decode byte-identically to the 64-bit output.

You might consider running the decoder tests on a 32-bit target in CI (the wasm32 lane currently only builds) — that lane would have caught this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)