### PR TITLE
feat(decoder): add wasi-test

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Runs wasm32-wasip1 test binaries under wasmtime (`cargo test --target
+# wasm32-wasip1`), with the working directory preopened for fixture access.
+[target.wasm32-wasip1]
+runner = ["wasmtime", "run", "--dir", "."]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,49 @@ jobs:
           gzip -k -9 probe-*.wasm opt-*.wasm
           ls -la probe-*.wasm probe-*.wasm.gz opt-*.wasm opt-*.wasm.gz
 
+  wasi-tests:
+    runs-on: ubuntu-latest
+    env:
+      DRACO_TAG: "1.5.7"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
+
+      - name: Cache Google Draco
+        uses: actions/cache@v4
+        with:
+          path: third_party/draco
+          key: draco-${{ runner.os }}-${{ env.DRACO_TAG }}-${{ hashFiles('scripts/build-draco.sh') }}
+
+      - name: Build Google Draco reference decoder
+        run: ./scripts/build-draco.sh
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: install wasmtime
+        run: |
+          curl -sSf https://wasmtime.dev/install.sh | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
+      # The codec crates' own unit tests on a 32-bit target, run under the
+      # wasmtime runner from .cargo/config.toml.
+      - name: unit tests on wasm32-wasip1
+        run: cargo test -p draco-oxide-core -p draco-oxide-decoder --target wasm32-wasip1
+
+      # Every profile test with the draco-oxide operations rerouted through the
+      # wasi-codec module, so the encoder and decoder run on wasm32 against
+      # the same fixtures and the same Google Draco round trips as natively.
+      - name: build wasi-codec
+        run: cargo build -p wasi-codec --target wasm32-wasip1 --release
+
+      - name: profile tests on wasm32-wasip1
+        env:
+          DRACO_OXIDE_WASM: target/wasm32-wasip1/release/wasi-codec.wasm
+        run: cargo test -p tests --test integrated_tests -- --nocapture
+
   tests:
     runs-on: ubuntu-latest
     env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,9 @@ under `draco-oxide/`:
 - **bench/**: unpublished benchmark against Google Draco (see below).
 - **wasm-size-probe/**: minimal C-ABI surface over the decoder used to
   measure linked WASM module size per feature tier.
+- **wasi-codec/**: unpublished file-in/file-out encode/decode binary over
+  `draco-oxide`, built for `wasm32-wasip1` so the profile tests can run the
+  codec under wasmtime (see Testing).
 
 ## The encoder's cascading index model
 
@@ -134,6 +137,25 @@ a list of operations run in order in a scratch dir:
 `tests/build.rs` generates one `#[test]` per profile; the test name is the
 file stem. Test data lives in `tests/data/`; derived data must carry the
 citation its license requires in the file header (see existing headers).
+
+### Profile tests on WASM
+
+The same profiles run with draco-oxide on a 32-bit WASM target, which is
+where `usize`-width bugs surface:
+
+```bash
+rustup target add wasm32-wasip1     # once; also install wasmtime
+cargo build -p wasi-codec --target wasm32-wasip1 --release
+DRACO_OXIDE_WASM=target/wasm32-wasip1/release/wasi-codec.wasm \
+  cargo test -p tests --test integrated_tests
+```
+
+`DRACO_OXIDE_WASM` reroutes every `DracoOxideEncode` / `DracoOxideDecode`
+through the module under `wasmtime` (`WASMTIME=<path>` if it is not on
+PATH); the reference-binary operations and comparisons are unchanged.
+`cargo test -p draco-oxide-core -p draco-oxide-decoder --target wasm32-wasip1`
+runs the unit tests on the same target via the runner in
+`.cargo/config.toml`. CI runs both.
 
 ## Bench
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,8 @@ DRACO_OXIDE_WASM=target/wasm32-wasip1/release/wasi-codec.wasm \
 
 `DRACO_OXIDE_WASM` reroutes every `DracoOxideEncode` / `DracoOxideDecode`
 through the module under `wasmtime` (`WASMTIME=<path>` if it is not on
-PATH); the reference-binary operations and comparisons are unchanged.
+PATH; a relative module path is taken from the workspace root); the
+reference-binary operations and comparisons are unchanged.
 `cargo test -p draco-oxide-core -p draco-oxide-decoder --target wasm32-wasip1`
 runs the unit tests on the same target via the runner in
 `.cargo/config.toml`. CI runs both.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["draco-oxide", "draco-oxide/core", "draco-oxide/decoder", "cli", "tests", "bench", "wasm-size-probe"]
+members = ["draco-oxide", "draco-oxide/core", "draco-oxide/decoder", "cli", "tests", "bench", "wasm-size-probe", "wasi-codec"]
 
 # Shared metadata for the version-locked draco-oxide library crates
 # (draco-oxide, draco-oxide-core, draco-oxide-decoder). Bump `version` in one

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -823,9 +823,18 @@ impl WasmCodec {
     const GUEST_DATA: &'static str = "/data";
 
     /// The opt-in is explicit, so a missing module or runtime is a failure,
-    /// never a silent fallback to the native codec.
+    /// never a silent fallback to the native codec. A relative module path is
+    /// resolved against the workspace root (cargo runs this crate's tests
+    /// with the `tests/` package dir as the working directory).
     fn from_env(name: &str, out_dir: &Path, data_dir: &Path) -> Option<Self> {
         let module = PathBuf::from(std::env::var_os("DRACO_OXIDE_WASM")?);
+        let module = if module.is_relative() {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join(module)
+        } else {
+            module
+        };
         assert!(
             module.is_file(),
             "[{name}] DRACO_OXIDE_WASM={} is not a file (build it with \

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -12,6 +12,10 @@
 //! those binaries aren't available — the same auto-skip behavior used by the
 //! existing `draco_decode` smoke test, so `cargo test` keeps passing on
 //! machines without Google Draco built.
+//!
+//! `DRACO_OXIDE_WASM=<path to wasi-codec.wasm>` reroutes the draco-oxide
+//! operations through that module under `wasmtime`, so the same profiles
+//! exercise the codec on a 32-bit WASM target (see [`WasmCodec`]).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -37,9 +41,30 @@ pub struct Profile {
     pub operations: Vec<Operation>,
 }
 
-/// serde default for `DracoOxideEncode::cfg` — the plain encoder default.
-fn default_oxide_cfg() -> oxide_encode::Config {
-    <oxide_encode::Config as ConfigType>::default()
+/// `DracoOxideEncode::cfg`: the encoder [`Config`](oxide_encode::Config)
+/// together with the TOML table it was parsed from, so the WASM codec path
+/// can hand the same configuration to the `wasi-codec` subprocess.
+#[derive(Debug, Clone)]
+pub struct OxideCfg {
+    pub table: toml::Table,
+    pub parsed: oxide_encode::Config,
+}
+
+impl Default for OxideCfg {
+    fn default() -> Self {
+        Self {
+            table: toml::Table::new(),
+            parsed: <oxide_encode::Config as ConfigType>::default(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OxideCfg {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let table = toml::Table::deserialize(d)?;
+        let parsed = table.clone().try_into().map_err(serde::de::Error::custom)?;
+        Ok(Self { table, parsed })
+    }
 }
 
 /// One step in a test profile.
@@ -79,8 +104,8 @@ pub enum Operation {
         output: String,
         #[serde(default)]
         timeout_secs: Option<f64>,
-        #[serde(default = "default_oxide_cfg")]
-        cfg: oxide_encode::Config,
+        #[serde(default)]
+        cfg: OxideCfg,
     },
     /// Decode a `.drc` with draco-oxide's own decoder, writing Wavefront OBJ.
     DracoOxideDecode { input: String, output: String },
@@ -275,6 +300,8 @@ pub fn run_profile(name: &str, profile_path: &str, data_dir: &str, outputs_dir: 
         return;
     }
 
+    let wasm_codec = WasmCodec::from_env(name, &out_dir, data_dir);
+
     std::fs::create_dir_all(&out_dir).unwrap_or_else(|e| {
         panic!(
             "[{name}] failed to create output dir {}: {e}",
@@ -303,25 +330,37 @@ pub fn run_profile(name: &str, profile_path: &str, data_dir: &str, outputs_dir: 
                 cfg,
             } => {
                 let in_path = resolve_input(input);
-                let buf = match timeout_secs {
-                    Some(secs) => encode_oxide_with_timeout(
+                let out_path = resolve_output(output);
+                let timeout = timeout_secs.map(Duration::from_secs_f64);
+                if let Some(wasm) = &wasm_codec {
+                    let cfg_path = (!cfg.table.is_empty()).then(|| {
+                        let path = out_dir.join(format!("op{idx}.cfg.toml"));
+                        std::fs::write(&path, cfg.table.to_string()).unwrap_or_else(|e| {
+                            panic!("{label}: writing {} failed: {e}", path.display())
+                        });
+                        path
+                    });
+                    wasm.encode(&label, &in_path, &out_path, cfg_path.as_deref(), timeout);
+                    continue;
+                }
+                let buf = match timeout {
+                    Some(timeout) => encode_oxide_with_timeout(
                         &label,
                         in_path.clone(),
-                        Duration::from_secs_f64(*secs),
-                        cfg.clone(),
+                        timeout,
+                        cfg.parsed.clone(),
                     ),
                     None => {
                         let mesh = load_mesh_for_oxide(&in_path).unwrap_or_else(|e| {
                             panic!("{label}: failed to load {}: {e}", in_path.display())
                         });
                         let mut buf = Vec::new();
-                        oxide_encode_fn(mesh, &mut buf, cfg.clone()).unwrap_or_else(|e| {
+                        oxide_encode_fn(mesh, &mut buf, cfg.parsed.clone()).unwrap_or_else(|e| {
                             panic!("{label}: draco-oxide encode failed: {e:?}")
                         });
                         buf
                     }
                 };
-                let out_path = resolve_output(output);
                 std::fs::write(&out_path, &buf).unwrap_or_else(|e| {
                     panic!("{label}: writing {} failed: {e}", out_path.display())
                 });
@@ -329,6 +368,10 @@ pub fn run_profile(name: &str, profile_path: &str, data_dir: &str, outputs_dir: 
             Operation::DracoOxideDecode { input, output } => {
                 let in_path = resolve_input(input);
                 let out_path = resolve_output(output);
+                if let Some(wasm) = &wasm_codec {
+                    wasm.decode(&label, &in_path, &out_path);
+                    continue;
+                }
                 draco_oxide::io::obj::decode_drc_to_obj(&in_path, &out_path).unwrap_or_else(|e| {
                     panic!(
                         "{label}: draco-oxide decode of {} failed: {e}",
@@ -752,6 +795,136 @@ fn triangle_area(
     v2: parry3d::math::Vector,
 ) -> f64 {
     0.5 * (v1 - v0).cross(v2 - v0).length() as f64
+}
+
+// ---------------------------------------------------------------------------
+// draco-oxide under a WASM runtime
+// ---------------------------------------------------------------------------
+
+/// Runs `DracoOxideEncode` / `DracoOxideDecode` through the `wasi-codec`
+/// module under `wasmtime` instead of in-process, so every profile exercises
+/// the codec on a 32-bit target. Enabled by `DRACO_OXIDE_WASM=<path to
+/// wasi-codec.wasm>` (build it with `cargo build -p wasi-codec --target
+/// wasm32-wasip1 --release`); `WASMTIME` overrides the runtime binary.
+///
+/// The guest sees the profile's output dir as `/out` and the data dir as
+/// `/data`; host paths are translated on the way in.
+struct WasmCodec {
+    runtime: PathBuf,
+    module: PathBuf,
+    out_dir: PathBuf,
+    data_dir: PathBuf,
+}
+
+impl WasmCodec {
+    /// Guest mount point of the profile's output dir.
+    const GUEST_OUT: &'static str = "/out";
+    /// Guest mount point of the shared test data dir.
+    const GUEST_DATA: &'static str = "/data";
+
+    /// The opt-in is explicit, so a missing module or runtime is a failure,
+    /// never a silent fallback to the native codec.
+    fn from_env(name: &str, out_dir: &Path, data_dir: &Path) -> Option<Self> {
+        let module = PathBuf::from(std::env::var_os("DRACO_OXIDE_WASM")?);
+        assert!(
+            module.is_file(),
+            "[{name}] DRACO_OXIDE_WASM={} is not a file (build it with \
+             `cargo build -p wasi-codec --target wasm32-wasip1 --release`)",
+            module.display()
+        );
+        let runtime = PathBuf::from(std::env::var_os("WASMTIME").unwrap_or("wasmtime".into()));
+        Some(Self {
+            runtime,
+            module,
+            out_dir: out_dir.to_path_buf(),
+            data_dir: data_dir.to_path_buf(),
+        })
+    }
+
+    fn encode(
+        &self,
+        label: &str,
+        input: &Path,
+        output: &Path,
+        cfg: Option<&Path>,
+        timeout: Option<Duration>,
+    ) {
+        let mut cmd = self.command();
+        cmd.arg("encode")
+            .arg(self.guest_path(label, input))
+            .arg(self.guest_path(label, output));
+        if let Some(cfg) = cfg {
+            cmd.arg(self.guest_path(label, cfg));
+        }
+        let stdout = self.run(label, cmd);
+        let secs: f64 = stdout
+            .lines()
+            .find_map(|l| l.strip_prefix("encode_secs="))
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or_else(|| panic!("{label}: wasi-codec did not report encode_secs"));
+        if let Some(timeout) = timeout {
+            assert!(
+                secs <= timeout.as_secs_f64(),
+                "{label}: draco-oxide (wasm) encode took {secs:.3}s, exceeding timeout of {timeout:?}"
+            );
+        }
+    }
+
+    fn decode(&self, label: &str, input: &Path, output: &Path) {
+        let mut cmd = self.command();
+        cmd.arg("decode")
+            .arg(self.guest_path(label, input))
+            .arg(self.guest_path(label, output));
+        self.run(label, cmd);
+    }
+
+    fn command(&self) -> Command {
+        let mut cmd = Command::new(&self.runtime);
+        cmd.arg("run")
+            .arg("--dir")
+            .arg(format!("{}::{}", self.out_dir.display(), Self::GUEST_OUT))
+            .arg("--dir")
+            .arg(format!("{}::{}", self.data_dir.display(), Self::GUEST_DATA))
+            .arg(&self.module);
+        cmd
+    }
+
+    fn run(&self, label: &str, mut cmd: Command) -> String {
+        let output = cmd.output().unwrap_or_else(|e| {
+            panic!(
+                "{label}: failed to spawn {} (set WASMTIME=<path> if it is not on PATH): {e}",
+                self.runtime.display()
+            )
+        });
+        if !output.status.success() {
+            panic!(
+                "{label}: wasi-codec failed with {}\n    stdout: {}\n    stderr: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
+            );
+        }
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn guest_path(&self, label: &str, host: &Path) -> String {
+        let (root, guest) = if let Ok(rel) = host.strip_prefix(&self.out_dir) {
+            (rel, Self::GUEST_OUT)
+        } else if let Ok(rel) = host.strip_prefix(&self.data_dir) {
+            (rel, Self::GUEST_DATA)
+        } else {
+            panic!(
+                "{label}: {} is outside the output and data dirs",
+                host.display()
+            )
+        };
+        let mut path = guest.to_string();
+        for component in root.components() {
+            path.push('/');
+            path.push_str(&component.as_os_str().to_string_lossy());
+        }
+        path
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/wasi-codec/Cargo.toml
+++ b/wasi-codec/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wasi-codec"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+# Internal test harness binary: a file-in/file-out encode/decode front end over
+# `draco-oxide`, built for `wasm32-wasip1` so the profile tests can run the
+# codec under a WASM runtime (`DRACO_OXIDE_WASM=<module> cargo test -p tests`)
+# and catch target-width bugs that 64-bit hosts hide. Not a shipping artifact.
+
+[dependencies]
+draco-oxide = { path = "../draco-oxide" }
+toml = "0.8"

--- a/wasi-codec/src/main.rs
+++ b/wasi-codec/src/main.rs
@@ -1,0 +1,62 @@
+//! File-in/file-out front end over `draco-oxide` for the profile-test harness.
+//!
+//! ```text
+//! wasi-codec encode <input.obj> <output.drc> [config.toml]
+//! wasi-codec decode <input.drc> <output.obj>
+//! ```
+//!
+//! `encode` prints `encode_secs=<f64>` (the encode alone, excluding the OBJ
+//! load and the output write) to stdout so the harness can enforce
+//! `timeout_secs` on the same region it times natively.
+
+use std::process::ExitCode;
+use std::time::Instant;
+
+use draco_oxide::core::types::ConfigType;
+use draco_oxide::encode::{encode_mesh, Config};
+use draco_oxide::io::obj::{decode_drc_to_obj, load_obj};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let result = match args.iter().map(String::as_str).collect::<Vec<_>>()[..] {
+        [_, "encode", input, output] => encode(input, output, None),
+        [_, "encode", input, output, config] => encode(input, output, Some(config)),
+        [_, "decode", input, output] => decode(input, output),
+        _ => Err(
+            "usage: wasi-codec encode <input.obj> <output.drc> [config.toml]\n       \
+             wasi-codec decode <input.drc> <output.obj>"
+                .to_string(),
+        ),
+    };
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("wasi-codec: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn encode(input: &str, output: &str, config: Option<&str>) -> Result<(), String> {
+    let cfg = match config {
+        Some(path) => {
+            let text = std::fs::read_to_string(path)
+                .map_err(|e| format!("failed to read config {path}: {e}"))?;
+            toml::from_str::<Config>(&text)
+                .map_err(|e| format!("failed to parse config {path}: {e}"))?
+        }
+        None => <Config as ConfigType>::default(),
+    };
+    let mesh = load_obj(input).map_err(|e| format!("failed to load {input}: {e}"))?;
+
+    let start = Instant::now();
+    let mut buf = Vec::new();
+    encode_mesh(mesh, &mut buf, cfg).map_err(|e| format!("encode failed: {e:?}"))?;
+    println!("encode_secs={}", start.elapsed().as_secs_f64());
+
+    std::fs::write(output, &buf).map_err(|e| format!("failed to write {output}: {e}"))
+}
+
+fn decode(input: &str, output: &str) -> Result<(), String> {
+    decode_drc_to_obj(input, output).map_err(|e| format!("decode of {input} failed: {e}"))
+}


### PR DESCRIPTION
This PR adds the WASI support for the profile tests. CI now runs the profile tests twice, one with native and the other with WASI.